### PR TITLE
Modify subscription attributes.

### DIFF
--- a/etc/policy.json.sample
+++ b/etc/policy.json.sample
@@ -19,6 +19,7 @@
     "topics:update": "",
 
     "messages:consume": "",
+    "messages:publish": "",
     "messages:get_all": "",
     "messages:create": "",
     "messages:get": "",

--- a/zaqar/storage/base.py
+++ b/zaqar/storage/base.py
@@ -455,6 +455,18 @@ class Topic(ControllerBase):
 
     _create = abc.abstractmethod(lambda x: None)
 
+    def exists(self, name, project=None):
+        """Base method for testing topic existence.
+
+        :param name: The topic name
+        :param project: Project id
+        :returns: True if a topic exists and False
+            if it does not.
+        """
+        return self._exists(name, project)
+
+    _exists = abc.abstractmethod(lambda x: None)
+
     def get(self, name, project=None):
         """Base method for topic metadata retrieval.
 
@@ -465,6 +477,8 @@ class Topic(ControllerBase):
         :raises: DoesNotExist
         """
         return self._get(name, project)
+
+    _get = abc.abstractmethod(lambda x: None)
 
     def delete(self, name, project=None):
         """Base method for deleting a topic.

--- a/zaqar/storage/mongodb/topics.py
+++ b/zaqar/storage/mongodb/topics.py
@@ -169,6 +169,13 @@ class TopicController(storage.Topic):
     def _delete(self, name, project=None):
         self._collection.remove(_get_scoped_query(name, project))
 
+    @utils.raises_conn_error
+    @utils.retries_on_autoreconnect
+    @decorators.caches(_topic_exists_key, _TOPIC_CACHE_TTL, lambda v: v)
+    def _exists(self, name, project=None):
+        query = _get_scoped_query(name, project)
+        return self._collection.find_one(query) is not None
+
 
 def _get_scoped_query(name, project):
     return {'p_t': utils.scope_queue_name(name, project)}

--- a/zaqar/transport/wsgi/v2_0/__init__.py
+++ b/zaqar/transport/wsgi/v2_0/__init__.py
@@ -123,18 +123,18 @@ def public_endpoints(driver, conf):
          ping.Resource(driver._storage)),
 
         # Subscription Endpoints
-        ('/queues/{queue_name}/subscriptions',
+        ('/topics/{topic_name}/subscriptions',
          subscriptions.CollectionResource(driver._validate,
                                           subscription_controller,
                                           defaults.subscription_ttl,
-                                          queue_controller,
+                                          topic_controller,
                                           conf)),
 
-        ('/queues/{queue_name}/subscriptions/{subscription_id}',
+        ('/topics/{topic_name}/subscriptions/{subscription_id}',
          subscriptions.ItemResource(driver._validate,
                                     subscription_controller)),
 
-        ('/queues/{queue_name}/subscriptions/{subscription_id}/confirm',
+        ('/topics/{topic_name}/subscriptions/{subscription_id}/confirm',
          subscriptions.ConfirmResource(driver._validate,
                                        subscription_controller,
                                        conf)),

--- a/zaqar/transport/wsgi/v2_0/__init__.py
+++ b/zaqar/transport/wsgi/v2_0/__init__.py
@@ -95,6 +95,12 @@ def public_endpoints(driver, conf):
         ('/queues/{queue_name}/messages/{message_id}',
          messages.ItemResource(message_controller)),
 
+        ('/topics/{topic_name}/messages',
+         messages.TopicResource(driver._validate,
+                                message_controller,
+                                topic_controller,
+                                defaults.message_ttl)),
+
         ('/queues/{queue_name}/consume',
          consume.CollectionResource(driver._wsgi_conf,
                                     driver._validate,

--- a/zaqar/transport/wsgi/v2_0/homedoc.py
+++ b/zaqar/transport/wsgi/v2_0/homedoc.py
@@ -119,6 +119,19 @@ JSON_HOME = {
                 'accept-post': ['application/json'],
             },
         },
+        'rel/publish_messages': {
+            'href-template': '/v2/topics/{topic_name}/messages',
+            'href-vars': {
+                'topic_name': 'param/topic_name',
+            },
+            'hints': {
+                'allow': ['POST'],
+                'formats': {
+                    'application/json': {},
+                },
+                'accept-post': ['application/json'],
+            },
+        },
         'rel/messages_delete': {
             'href-template': '/v2/queues/{queue_name}/messages{?ids,pop}',
             'href-vars': {

--- a/zaqar/transport/wsgi/v2_0/homedoc.py
+++ b/zaqar/transport/wsgi/v2_0/homedoc.py
@@ -229,9 +229,9 @@ JSON_HOME = {
         # Subscriptions
         # -----------------------------------------------------------------
         'rel/subscriptions_get': {
-            'href-template': '/v2/queues/{queue_name}/subscriptions{?marker,limit}',  # noqa
+            'href-template': '/v2/topics/{topic_name}/subscriptions{?marker,limit}',  # noqa
             'href-vars': {
-                'queue_name': 'param/queue_name',
+                'topic_name': 'param/topic_name',
                 'marker': 'param/marker',
                 'limit': 'param/subscription_limit',
             },
@@ -243,9 +243,9 @@ JSON_HOME = {
             }
         },
         'rel/subscriptions_post': {
-            'href-template': '/v2/queues/{queue_name}/subscriptions',
+            'href-template': '/v2/topics/{topic_name}/subscriptions',
             'href-vars': {
-                'queue_name': 'param/queue_name',
+                'topic_name': 'param/topic_name',
                 'limit': 'param/subscription_limit',
             },
             'hints': {
@@ -257,9 +257,9 @@ JSON_HOME = {
             }
         },
         'rel/subscription': {
-            'href-template': '/v2/queues/{queue_name}/subscriptions/{subscriptions_id}',  # noqa
+            'href-template': '/v2/topics/{topic_name}/subscriptions/{subscriptions_id}',  # noqa
             'href-vars': {
-                'queue_name': 'param/queue_name',
+                'topic_name': 'param/topic_name',
                 'subscriptions_id': 'param/subscriptions_id',
             },
             'hints': {
@@ -270,9 +270,9 @@ JSON_HOME = {
             }
         },
         'rel/subscription_patch': {
-            'href-template': '/v2/queues/{queue_name}/subscriptions/{subscriptions_id}',  # noqa
+            'href-template': '/v2/topics/{topic_name}/subscriptions/{subscriptions_id}',  # noqa
             'href-vars': {
-                'queue_name': 'param/queue_name',
+                'topic_name': 'param/topic_name',
                 'subscriptions_id': 'param/subscriptions_id',
             },
             'hints': {


### PR DESCRIPTION
1. Change the queue to tipic for subscriber.
2. Remove unnecessary attributes in the demand, such as subscription
expiration, and currently require subscriptions to take effect forever.
3. Support for modifying the options properties. Includes tags, retry
policies, etc..

Feature-ES #10991