### PR TITLE
Fix consume exception when queue is not found.

### DIFF
--- a/zaqar/transport/wsgi/v2_0/consume.py
+++ b/zaqar/transport/wsgi/v2_0/consume.py
@@ -64,9 +64,9 @@ class CollectionResource(object):
             queue_meta = self._queue_controller.get_metadata(queue_name,
                                                              project_id)
         except storage_errors.DoesNotExist as ex:
-            self._validate.identification(queue_name, project_id)
-            self._queue_controller.create(queue_name, project=project_id)
-            queue_meta = {}
+            raise wsgi_errors.HTTPNotFound('Queue %s is not found '
+                                           'in project %s' % (queue_name,
+                                                              project_id))
 
         queue_claim_ttl = queue_meta.get('claim_ttl', 1)
         metadata = {'grace': 0}


### PR DESCRIPTION
This patch solves two problems:
1. According to the product requirements,non-existent queues should raise a 404 error instead of automatically creating a new one.
2. As the deletion of the automatic creation and verification of the name
of the queue call `identification`, the function `identification` does not
exist, this is a legacy problem. This solved 500 errors.

Redmine: http://192.168.15.2/issues/11172