### PR TITLE
Add monitor for queue when subscriber is a queue.

### DIFF
--- a/zaqar/notification/tasks/queue.py
+++ b/zaqar/notification/tasks/queue.py
@@ -58,6 +58,9 @@ class QueueTask(object):
                 monitor_controller.update(messages, subscription['source'],
                                           project_id, 'subscribe_messages',
                                           success=True)
+
+                monitor_controller.update(messages, queue_name,
+                                          project_id, 'send_messages')
             except Exception as ex:
                 LOG.exception(ex)
 


### PR DESCRIPTION
At present, when subscriber is a queue, the queue's monitor data is not
updated if sent message to topic. This commit is to fix this problem.

Redmine: http://192.168.15.2/issues/11175