### PR TITLE
Fix the validation bug of message length

### DIFF
--- a/zaqar/transport/validation.py
+++ b/zaqar/transport/validation.py
@@ -420,7 +420,7 @@ class Validator(object):
         if content_length is None:
             return
 
-        if max_msg_post_size:
+        if max_msg_post_size is not None:
             try:
                 min_max_size = min(max_msg_post_size,
                                    self._limits_conf.max_messages_post_size)


### PR DESCRIPTION
When the `_max_messages_post_size` value is 0, the validation will be
failure.

Redmine: http://192.168.15.2/issues/11209